### PR TITLE
[Post] Fix link in "jar-hell"

### DIFF
--- a/content/articles/2015-10-19-jar-hell.md
+++ b/content/articles/2015-10-19-jar-hell.md
@@ -42,8 +42,7 @@ As the problem of unexpressed dependencies is compounded it becomes exponentiall
 ### Shadowing
 
 Sometimes different JARs on the classpath contain classes with the same fully-qualified name.
-This can happen for different reasons, e.g. when there are two different versions of the same library, when a [fat JAR](http://stackoverflow.com/q/19150811/2525313 "What is a fat JAR?
-- StackOverflow") contains dependencies that are also pulled in as standalone JARs, or when a library is renamed and unknowingly added to the classpath twice.
+This can happen for different reasons, e.g. when there are two different versions of the same library, when a [fat JAR](http://stackoverflow.com/q/19150811/2525313 "What is a fat JAR? - StackOverflow") contains dependencies that are also pulled in as standalone JARs, or when a library is renamed and unknowingly added to the classpath twice.
 
 Since classes will be loaded from the first JAR on the classpath to contain them, that variant will "shadow" all others and make them unavailable.
 


### PR DESCRIPTION
This fixes a StackOverflow link in the JAR Hell [Shadowing](https://nipafx.dev/jar-hell/#shadowing) section.